### PR TITLE
Added Config for ACLs

### DIFF
--- a/Kernel/Config/Files/TicketChecklist.xml
+++ b/Kernel/Config/Files/TicketChecklist.xml
@@ -96,4 +96,13 @@
             <String Regex="">Kernel::System::Ticket::Custom::TicketChecklist</String>
         </Setting>
     </ConfigItem>
+    <Setting Name="ACLKeysLevel3::Actions###100-Default-Checklist" Required="0" Valid="1">
+        <Description Translatable="1">Defines which items are available for 'Action' in third level of the ACL structure.</Description>
+        <Navigation>Core::Ticket::ACL</Navigation>
+        <Value>
+            <Array>
+                <Item>AgentTicketChecklist</Item>
+            </Array>
+        </Value>
+    </Setting>
 </otrs_config>

--- a/Kernel/Config/Files/XML/TicketChecklist.xml
+++ b/Kernel/Config/Files/XML/TicketChecklist.xml
@@ -156,4 +156,13 @@
             <Item ValueType="String" ValueRegex="">Kernel::System::Ticket::Custom::TicketChecklist</Item>
         </Value>
     </Setting>
+    <Setting Name="ACLKeysLevel3::Actions###100-Default-Checklist" Required="0" Valid="1">
+        <Description Translatable="1">Defines which items are available for 'Action' in third level of the ACL structure.</Description>
+        <Navigation>Core::Ticket::ACL</Navigation>
+        <Value>
+            <Array>
+                <Item>AgentTicketChecklist</Item>
+            </Array>
+        </Value>
+    </Setting>
 </otrs_config>


### PR DESCRIPTION
Hi!

First, congratulate you for your work and support for the community, you have helped me a lot in some ideas for my developments.

After reviewing this plugin in our system I had to add a configuration to include it in the ACL list and put a control to make it disappear in the closed tickets.

I send you a small update, it may be interesting to add it to new versions so there is no need to include it in the OTRS standard ACL configuration. As they do with the ITSM add-ons.

Regards,
Miguel.